### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+
+## 0.3.0 (2025-11-18)
+
+### Child Workspaces
+
+The following workspaces are included in this release:
+
+- 🔄 `/home/runner/work/javascript-extensions/javascript-extensions/packages/eslint` - v1.3.0
+- 🔄 `/home/runner/work/javascript-extensions/javascript-extensions/packages/prettier` - v1.1.0
+
+
+### Features
+
+* added support for toml files ([#48](https://github.com/templ-project/javascript-extensions/issues/48)) ([5b04ce6](https://github.com/templ-project/javascript-extensions/commit/5b04ce6930bdc8f69eaaa1c19b8855eba5a4c010))
+
+# Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
@@ -398,4 +415,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@templ-project/javascript",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Comprehensive JavaScript and TypeScript development toolkit with portable configurations for ESLint, Prettier, TSConfig, Vitest, and Commitlint",
   "main": "dist/index.js",
   "private": true,

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@templ-project/eslint",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "type": "module",
   "main": "index.js",
   "exports": {

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@templ-project/prettier",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "type": "module",
   "main": "index.cjs",
   "exports": {


### PR DESCRIPTION
# Version Update: @templ-project/javascript 0.3.0

## 📦 Workspace Versions

### 🏠 Root: @templ-project/javascript
**Version**: `0.2.3`  
**Path**: `/home/runner/work/javascript-extensions/javascript-extensions`  
**Type**: `node`  

### 📁 Child Workspaces

- 🔄 **@templ-project/eslint** `1.2.2`
  - Path: `/home/runner/work/javascript-extensions/javascript-extensions/packages/eslint`
  - Type: `node`
- 🔄 **@templ-project/prettier** `1.0.6`
  - Path: `/home/runner/work/javascript-extensions/javascript-extensions/packages/prettier`
  - Type: `node`